### PR TITLE
Train Result Visualization 기능 추가

### DIFF
--- a/fruit_recognition.py
+++ b/fruit_recognition.py
@@ -67,6 +67,24 @@ model_cnn.add(Activation('softmax'))
 model_cnn.summary()
 opt = keras.optimizers.Adam(lr=0.0001)
 
+# Plot training & validation accuracy values
+plt.plot(history.history['acc'])
+# plt.plot(history.history['val_acc'])
+plt.title('Model accuracy')
+plt.ylabel('Accuracy')
+plt.xlabel('Epoch')
+plt.legend(['Train', 'Test'], loc='upper left')
+plt.show()
+
+# Plot training & validation loss values
+plt.plot(history.history['loss'])
+# plt.plot(history.history['val_loss'])
+plt.title('Model loss')
+plt.ylabel('Loss')
+plt.xlabel('Epoch')
+plt.legend(['Train', 'Test'], loc='upper left')
+plt.show()
+
 # train the model using RMSprop
 model_cnn.compile(loss='categorical_crossentropy',
                             optimizer=opt,


### PR DESCRIPTION
안녕하세요.

#5 에서와 같이 모델의 학습 결과를 시각화하여 보여주는 기능을 추가했습니다.
해당 기능은 matplotlib.pyplot 모듈을 이용하여 구현했습니다.
아쉬운 점은 해당 모델에는 validation accuracy가 구현되어 있지 않아 그 부분은 표시가 안됩니다.

아래는 Lemon의 데이터로만 epoch=5로 모델을 학습한 결과를 시각화한 예시입니다.
감사합니다.

![zxc](https://user-images.githubusercontent.com/42177510/59561519-50e3ad00-905c-11e9-954c-1738e13c3f81.PNG)
